### PR TITLE
add valgrind output

### DIFF
--- a/homework/resourceD/valgrind-output.txt
+++ b/homework/resourceD/valgrind-output.txt
@@ -1,0 +1,25 @@
+valgrind --leak-check=full ./resourceD d
+==17231== Memcheck, a memory error detector
+==17231== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==17231== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
+==17231== Command: ./resourceD d
+==17231==
+Using resource. Passed d
+Passed d. d is prohibited.
+==17231==
+==17231== HEAP SUMMARY:
+==17231==     in use at exit: 1 bytes in 1 blocks
+==17231==   total heap usage: 5 allocs, 4 frees, 73,924 bytes allocated
+==17231==
+==17231== 1 bytes in 1 blocks are definitely lost in loss record 1 of 1
+==17231==    at 0x483BE63: operator new(unsigned long) (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
+==17231==    by 0x109372: main (resourceD.cpp:30)
+==17231==
+==17231== LEAK SUMMARY:
+==17231==    definitely lost: 1 bytes in 1 blocks
+==17231==    indirectly lost: 0 bytes in 0 blocks
+==17231==      possibly lost: 0 bytes in 0 blocks
+==17231==    still reachable: 0 bytes in 0 blocks
+==17231==         suppressed: 0 bytes in 0 blocks
+==17231==
+==17231== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)


### PR DESCRIPTION
w trakcie wyjątków powstają wycieki jeśli odpowiednio się nie zwolni pamięci, dlatego tu należałoby zastosować smart pointer lub napisać własny.