### PR TITLE
valgrind output added

### DIFF
--- a/homework/resourceD/valgrind-output.txt
+++ b/homework/resourceD/valgrind-output.txt
@@ -1,0 +1,27 @@
+valgrind --leak-check=full ./resourceD d
+==6945== Memcheck, a memory error detector
+==6945== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==6945== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
+==6945== Command: ./resourceD d
+==6945== 
+Using resource. Passed d
+Passed d. d is prohibited.
+==6945== 
+==6945== HEAP SUMMARY:
+==6945==     in use at exit: 1 bytes in 1 blocks
+==6945==   total heap usage: 5 allocs, 4 frees, 73,924 bytes allocated
+==6945== 
+==6945== 1 bytes in 1 blocks are definitely lost in loss record 1 of 1
+==6945==    at 0x483BE63: operator new(unsigned long) (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
+==6945==    by 0x109372: main (resourceD.cpp:30)
+==6945== 
+==6945== LEAK SUMMARY:
+==6945==    definitely lost: 1 bytes in 1 blocks
+==6945==    indirectly lost: 0 bytes in 0 blocks
+==6945==      possibly lost: 0 bytes in 0 blocks
+==6945==    still reachable: 0 bytes in 0 blocks
+==6945==         suppressed: 0 bytes in 0 blocks
+==6945== 
+==6945== For lists of detected and suppressed errors, rerun with: -s
+==6945== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
+


### PR DESCRIPTION
Memory leak detected. It occurs when user passes 'd' to main() as an argument.